### PR TITLE
Update to DEV dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ vendor
 
 # this is user specific settings for running phpunit to override the defaults in phpunit.xml.dist
 phpunit.xml
+.phpunit.result.cache
 
 # Don't commit composer.phar, or the .phar our build tool generates
 *.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,15 @@ language: php
 php:
     - 7.0
     - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
     - nightly
+matrix:
+    allow_failures:
+        - php: 7.4
+        - php: nightly
+    fast_finish: true
 install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get -qq update

--- a/composer.json
+++ b/composer.json
@@ -30,23 +30,23 @@
 		"brianseitel/oasis-mson-parser" : "dev-newest"
 	},
 	"require-dev" : {
-		"nikic/php-parser" : "^3.0",
-		"phpunit/phpunit" : "^6.1",
-		"squizlabs/php_codesniffer" : "^3.0",
-		"overtrue/phplint" : "^0.2.1",
-		"satooshi/php-coveralls" : "^1.0",
-		"phpstan/phpstan" : "^0.7.0"
+		"nikic/php-parser": "^4.2",
+		"squizlabs/php_codesniffer" : "3.*",
+		"overtrue/phplint": "^1.1",
+		"php-coveralls/php-coveralls": "^2.1",
+		"phpunit/phpunit": "^8",
+		"phpstan/phpstan": "^0.11.16"
 	},
 	"scripts" : {
 		"phpcs" : "phpcs --standard=PSR2 -n src",
 		"phpcbf" : "phpcbf --standard=PSR2 -n src",
-		"phplint" : "phplint src",
 		"unit" : "php -d phar.readonly=0 vendor/bin/phpunit --coverage-clover ./tests/log/clover.xml --colors=always",
-		"phpstan" : "vendor/bin/phpstan analyse src --level 7",
+		"phplint": "phplint ./ --exclude=vendor",
+		"phpstan" : "phpstan analyse src --level 7",
 		"test" : [
+			"@phplint",
 			"@unit",
-			"@phpcs",
-			"@phplint"
+			"@phpcs"
 		]
 	},
 	"bin" : [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/phpunit-bootstrap.php"
-         colors="true"
->
-    <logging>
-        <log type="coverage-html" target="./tests/log/report" charset="UTF-8"/>
-        <log type="coverage-clover" target="./tests/log/clover.xml"/>
-    </logging>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Parser Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
     <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <file>src/bootstrap.php</file>
-            </exclude>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <testsuite name="Parser Test Suite">
-        <directory>./tests/</directory>
-    </testsuite>
+    <logging>
+        <log type="coverage-clover" target="./clover.xml"/>
+    </logging>
 </phpunit>

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use BlueprintSdkMaker\Command\MakeCommand;
@@ -8,11 +9,11 @@ final class MakeCommandTest extends TestCase
 {
     protected $rootDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootDir = self::getUniqueTmpDirectory();
     }
-    
+
     public function testMakeCommandInvalidApibFile()
     {
         $command = new MakeCommand();
@@ -25,17 +26,17 @@ final class MakeCommandTest extends TestCase
         $output = $commandTester->getDisplay();
         $this->assertEquals("invalid apib file.\n", $output);
     }
-    
+
     public function testInvalidDrafterBinary()
     {
         $command = new MakeCommand();
         $commandTester = new CommandTester($command);
-        $apib_files = array_diff(scandir(__DIR__.'/fixtures'), array('..', '.'));
+        $apib_files = array_diff(scandir(__DIR__ . '/fixtures'), array('..', '.'));
 
         $commandTester->execute([
-            'apib-file' => __DIR__.DIRECTORY_SEPARATOR.
-                'fixtures'.DIRECTORY_SEPARATOR.
-                current($apib_files).DIRECTORY_SEPARATOR.
+            'apib-file' => __DIR__ . DIRECTORY_SEPARATOR .
+                'fixtures' . DIRECTORY_SEPARATOR .
+                current($apib_files) . DIRECTORY_SEPARATOR .
                 'ApiBlueprint.apib',
             '--directory' => $this->rootDir,
             '--namespace' => 'BlueprintApi',
@@ -45,7 +46,7 @@ final class MakeCommandTest extends TestCase
 
         $this->assertRegExp('/The drafter command is mandatory/', $output);
     }
-    
+
     /**
      * @dataProvider resourceProvider
      */
@@ -54,7 +55,7 @@ final class MakeCommandTest extends TestCase
         $command = new MakeCommand();
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            'apib-file' => $testDirectory->getRealPath().DIRECTORY_SEPARATOR.'ApiBlueprint.apib',
+            'apib-file' => $testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'ApiBlueprint.apib',
             '--directory' => $this->rootDir,
             '--namespace' => 'BlueprintApi',
             '--no-phar' => true
@@ -63,10 +64,10 @@ final class MakeCommandTest extends TestCase
         $this->assertRegExp('/Generate .*.php/', $output);
 
         $expectedFinder = new Finder();
-        $expectedFinder->in($testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'expected'.DIRECTORY_SEPARATOR.'src/');
+        $expectedFinder->in($testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'expected' . DIRECTORY_SEPARATOR . 'src/');
 
         $generatedFinder = new Finder();
-        $generatedFinder->in($this->rootDir.DIRECTORY_SEPARATOR.'src');
+        $generatedFinder->in($this->rootDir . DIRECTORY_SEPARATOR . 'src');
 
         $this->assertEquals(count($expectedFinder), count($generatedFinder), 'Failure in generate files');
 
@@ -80,7 +81,7 @@ final class MakeCommandTest extends TestCase
             if ($expectedFile->isFile()) {
                 $expectedPath = $expectedFile->getRealPath();
                 $path = $expectedFile->getRelativePathname();
-                $actualPath   = $generatedData[ $expectedFile->getRelativePathname() ];
+                $actualPath = $generatedData[$expectedFile->getRelativePathname()];
                 //file_put_contents($expectedPath, file_get_contents($actualPath));
                 $this->assertFileEquals(
                     $expectedPath,
@@ -93,25 +94,25 @@ final class MakeCommandTest extends TestCase
 
     public function testMakePhar()
     {
-        $apib_files = array_diff(scandir(__DIR__.'/fixtures'), array('..', '.'));
+        $apib_files = array_diff(scandir(__DIR__ . '/fixtures'), array('..', '.'));
         $command = new MakeCommand();
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            'apib-file' => __DIR__.DIRECTORY_SEPARATOR.
-                'fixtures'.DIRECTORY_SEPARATOR.
-                current($apib_files).DIRECTORY_SEPARATOR.
+            'apib-file' => __DIR__ . DIRECTORY_SEPARATOR .
+                'fixtures' . DIRECTORY_SEPARATOR .
+                current($apib_files) . DIRECTORY_SEPARATOR .
                 'ApiBlueprint.apib',
             '--directory' => $this->rootDir,
             '--namespace' => 'BlueprintApi',
         ]);
-        $this->assertFileExists($this->rootDir.DIRECTORY_SEPARATOR.'api.phar');
+        $this->assertFileExists($this->rootDir . DIRECTORY_SEPARATOR . 'api.phar');
 
         ini_set('phar.readonly', 1);
-        
+
         $commandTester->execute([
-            'apib-file' => __DIR__.DIRECTORY_SEPARATOR.
-                'fixtures'.DIRECTORY_SEPARATOR.
-                current($apib_files).DIRECTORY_SEPARATOR.
+            'apib-file' => __DIR__ . DIRECTORY_SEPARATOR .
+                'fixtures' . DIRECTORY_SEPARATOR .
+                current($apib_files) . DIRECTORY_SEPARATOR .
                 'ApiBlueprint.apib',
             '--directory' => $this->rootDir,
             '--namespace' => 'BlueprintApi',
@@ -119,57 +120,52 @@ final class MakeCommandTest extends TestCase
         $output = $commandTester->getDisplay();
         $this->assertRegExp('/Enable phar.readonly into php.ini setting phar.readonly to 0/', $output);
     }
-    
+
     public function resourceProvider()
     {
         $finder = new Finder();
-        $finder->directories()->in(__DIR__.'/fixtures');
+        $finder->directories()->in(__DIR__ . '/fixtures');
         $finder->depth('< 1');
-        
+
         $data = array();
-        
+
         foreach ($finder as $directory) {
             $data[] = [$directory];
         }
-        
+
         return $data;
     }
 
-    
+
     public static function getUniqueTmpDirectory()
     {
         $attempts = 5;
         $root = sys_get_temp_dir();
-        
+
         do {
             $unique = $root . DIRECTORY_SEPARATOR . uniqid('blueprint-sdk-maker-test-' . rand(1000, 9000));
-            
+
             if (!file_exists($unique) && mkdir($unique, 0777)) {
                 return realpath($unique);
             }
         } while (--$attempts);
-        
+
         throw new \RuntimeException('Failed to create a unique temporary directory.');
     }
-    
+
     private function rrmdir($dir)
     {
         if (is_dir($dir)) {
             $objects = scandir($dir);
             foreach ($objects as $object) {
                 if ($object != "." && $object != "..") {
-                    if (is_dir($dir."/".$object))
-                        $this->rrmdir($dir."/".$object);
-                        else
-                            unlink($dir."/".$object);
+                    if (is_dir($dir . "/" . $object))
+                        $this->rrmdir($dir . "/" . $object);
+                    else
+                        unlink($dir . "/" . $object);
                 }
             }
             rmdir($dir);
-        } 
-    }
-    
-    protected function tearDown()
-    {
-        //$this->rrmdir($this->rootDir);
+        }
     }
 }


### PR DESCRIPTION
Resolving `dev` part of: https://github.com/vitormattos/blueprint-sdk-maker/issues/8

This PR contains:
- Updated `.travis.yml` file, supporting 7.2, 7.3 and soft fail 7.4.
- Upgrade PHP-unit to 8.x
- Replace `satooshi/php-coveralls` with `php-coveralls/php-coveralls`

If wanted, I can also push some overall code improvements in the SDK.